### PR TITLE
Force Set To Bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest AS builder
+FROM rust:bullseye as builder
 
 WORKDIR /drone
 


### PR DESCRIPTION
Debian Bookworm(12) got released and it has OpenSSL3 by default. OpenSSL1.1 is still needed and we need to set to Debian bulleye(11) to get that working for now.

Resolves https://github.com/DeathwingTheBoss/drone/issues/3